### PR TITLE
Adds example of how to bypass intentionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ class Baz {}
 
 export default Foo;
 export { Bar, Baz }
+
+import { Moo } from './Moo';
+export const Baz = Moo;
 ```
 
 ## Usage

--- a/src/rules/tests/no-barrel-files.test.ts
+++ b/src/rules/tests/no-barrel-files.test.ts
@@ -14,7 +14,11 @@ ruleTester.run('no-barrel-files', noBarrelFiles, {
       
       export default Foo;
       export { Bar, Baz }
-`,
+    `,
+    `
+      import Foo from "./foo";
+      export const Bar = Foo;
+    `,
   ],
   invalid: [
     {


### PR DESCRIPTION
Hi there :wave: I was setting up a new project recently and wanted to make sure we avoid barrel files. I was about to write my own ESLint rule when I discovered that someone had (recently!) created a rule for this. Thank you! Great job on linking to resources on _why_ barrel files should be avoided, too.

The approach here is different from what I was thinking. I wanted a rule that could identify entire files that are _only_ barrel files; this rule thinks about them as something the file _does_, as individual re-exports. I think this approach is better, especially in the context of a lint rule. 

One issue, though, is that sometimes we _do_ need to re-export an identifier from an otherwise non-barrel file. Reading the source code, it seemed like the workaround here is to `export const NewIdentifier = ImportedIdentifier;`. But I had to read the source code to make sure. This PR clarifies the readme to help others, and adds a unit tests to make sure the example continues to work.

Thanks again for the nice lint rule 👍 