### PR TITLE
fix: #2 with named exports, the exported name instead of the local name would be checked

### DIFF
--- a/src/rules/no-barrel-files.ts
+++ b/src/rules/no-barrel-files.ts
@@ -49,7 +49,7 @@ const noBarrelFiles: TSESLint.RuleModule<MessageIds> = {
         }
 
         node.specifiers.forEach(specifier => {
-          if (declaredImports.includes(specifier.exported.name)) {
+          if (declaredImports.includes(specifier.local.name)) {
             context.report({
               node: specifier,
               messageId: 'noReExport',

--- a/src/rules/tests/no-barrel-files.test.ts
+++ b/src/rules/tests/no-barrel-files.test.ts
@@ -8,16 +8,23 @@ const ruleTester = new RuleTester({
 ruleTester.run('no-barrel-files', noBarrelFiles, {
   valid: [
     `
-      const Foo = 'baz';
-      function Bar() {}
-      class Baz {}
-      
+      const Foo = () => {};
+      export { Foo }
+    `,
+    `
+      export const Foo = () => {};
+    `,
+    `
+      const Foo = () => {};
       export default Foo;
-      export { Bar, Baz }
     `,
     `
       import Foo from "./foo";
       export const Bar = Foo;
+    `,
+    `
+      import Foo from './foo';
+      export { Bar as Foo };
     `,
   ],
   invalid: [
@@ -52,6 +59,13 @@ ruleTester.run('no-barrel-files', noBarrelFiles, {
     {
       code: `
       export { default as Moo } from './Moo';
+      `,
+      errors: [{ messageId: 'noReExport' }],
+    },
+    {
+      code: `
+      import Foo from './Moo';
+      export { Foo as Bar };
       `,
       errors: [{ messageId: 'noReExport' }],
     },


### PR DESCRIPTION
See #2 

Before, this would fail:

```js
import Foo from './foo';
export { Bar as Foo };
```
In the export declaration, `Foo` would be checked against the list of imported members, rather than `Bar`.