### PR TITLE
fix: ensure 'error' is inferred as literal type in flat config

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - run: npm ci

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ const plugin = {
     rules: {
       'no-barrel-files/no-barrel-files': 'error',
     },
-  },
+  } satisfies TSESLint.FlatConfig.Config,
 };
 
 export = plugin;


### PR DESCRIPTION
In the current implementation, the following error occurs when loading flat config:

```
eslint.config.mjs:49:5 - error TS2345: Argument of type '{ plugins: { 'no-barrel-files': { rules: { 'no-barrel-files': RuleModule<"noReExport" | "noExportAll", [], unknown, RuleListener>; }; }; }; rules: { 'no-barrel-files/no-barrel-files': string; }; }' is not assignable to parameter of type 'InfiniteDepthConfigWithExtends'.
  Type '{ plugins: { 'no-barrel-files': { rules: { 'no-barrel-files': RuleModule<"noReExport" | "noExportAll", [], unknown, RuleListener>; }; }; }; rules: { 'no-barrel-files/no-barrel-files': string; }; }' is not assignable to type 'ConfigWithExtends'.
    Types of property 'rules' are incompatible.
      Type '{ 'no-barrel-files/no-barrel-files': string; }' is not assignable to type 'Partial<Record<string, RuleEntry>>'.
        Property ''no-barrel-files/no-barrel-files'' is incompatible with index signature.
          Type 'string' is not assignable to type 'RuleEntry | undefined'.
```

The error occurs because TypeScript-ESLint expects `RuleEntry` type (`'error' | 'warn' | 'off' | 0 | 1 | 2 | ...`) but receives `string` type instead.

This fix ensures that `'error'` is correctly inferred as a literal type rather than being widened to `string`, resolving the type compatibility issue with TypeScript-ESLint's flat config.
