### PR TITLE
ci: add release-please major override labels

### DIFF
--- a/.github/workflows/release-please-overrides.yml
+++ b/.github/workflows/release-please-overrides.yml
@@ -51,13 +51,14 @@ jobs:
       - name: Update release PR title
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           version="$(
-            gh api "repos/${{ github.repository }}/contents/package.json?ref=${{ github.event.pull_request.head.ref }}" \
+            gh api "repos/${{ github.repository }}/contents/package.json?ref=${RELEASE_PR_HEAD_REF}" \
               --jq '.content' | base64 --decode | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version"
           )"
           package_name="$(
-            gh api "repos/${{ github.repository }}/contents/package.json?ref=${{ github.event.pull_request.head.ref }}" \
+            gh api "repos/${{ github.repository }}/contents/package.json?ref=${RELEASE_PR_HEAD_REF}" \
               --jq '.content' | base64 --decode | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).name"
           )"
           gh pr edit "${{ github.event.pull_request.number }}" --title "chore(main): release ${package_name} ${version}"

--- a/.github/workflows/release-please-overrides.yml
+++ b/.github/workflows/release-please-overrides.yml
@@ -1,0 +1,63 @@
+name: release please overrides
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+      - unlabeled
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: release-please-overrides-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  release-please:
+    if: >-
+      startsWith(github.event.pull_request.head.ref, 'release-please--branches--') &&
+      (github.event.label.name == 'release:major' || contains(join(github.event.pull_request.labels.*.name, ','), 'release:major'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+      - name: Determine release override
+        env:
+          RELEASE_PLEASE_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          override=''
+          if printf '%s' ",${RELEASE_PLEASE_LABELS}," | grep -q ',release:major,'; then
+            override='release:major'
+          fi
+          echo "release_override=${override}" >> "$GITHUB_OUTPUT"
+        id: override
+      - name: Generate release-please config
+        env:
+          RELEASE_PLEASE_OVERRIDE: ${{ steps.override.outputs.release_override }}
+        run: node ./scripts/create-release-please-config.mjs
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          config-file: .github/release-please-config.generated.json
+          manifest-file: .release-please-manifest.json
+          target-branch: ${{ github.event.pull_request.base.ref }}
+      - name: Update release PR title
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version="$(
+            gh api "repos/${{ github.repository }}/contents/package.json?ref=${{ github.event.pull_request.head.ref }}" \
+              --jq '.content' | base64 --decode | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version"
+          )"
+          package_name="$(
+            gh api "repos/${{ github.repository }}/contents/package.json?ref=${{ github.event.pull_request.head.ref }}" \
+              --jq '.content' | base64 --decode | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).name"
+          )"
+          gh pr edit "${{ github.event.pull_request.number }}" --title "chore(main): release ${package_name} ${version}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: release-please-${{ github.ref }}
   cancel-in-progress: true
@@ -19,7 +22,23 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+      - name: Determine release override
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          labels="$(gh pr list --base main --state open --json headRefName,labels --jq '[.[] | select(.headRefName | startswith("release-please--branches--")) | .labels[].name] | unique | join(",")')"
+          override=''
+          if printf '%s' ",${labels}," | grep -q ',release:major,'; then
+            override='release:major'
+          fi
+          echo "release_override=${override}" >> "$GITHUB_OUTPUT"
+        id: override
+      - name: Generate release-please config
+        env:
+          RELEASE_PLEASE_OVERRIDE: ${{ steps.override.outputs.release_override }}
+        run: node ./scripts/create-release-please-config.mjs
       - uses: googleapis/release-please-action@v4
         with:
-          config-file: .github/release-please-config.json
+          config-file: .github/release-please-config.generated.json
           manifest-file: .release-please-manifest.json

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lockfile:check": "git diff --exit-code -- package-lock.json",
     "pack:smoke": "npm run build && node ./scripts/smoke-pack.mjs",
     "consumer:smoke": "npm run build && node ./scripts/smoke-consumer.mjs",
+    "release:please:config": "node ./scripts/create-release-please-config.mjs",
     "version:canary": "node ./scripts/version-canary.mjs"
   },
   "files": [

--- a/scripts/create-release-please-config.mjs
+++ b/scripts/create-release-please-config.mjs
@@ -1,0 +1,40 @@
+/**
+ * Generates a release-please config file for CI. The base config stays checked
+ * in, while temporary maintainer overrides can force an exact version when a
+ * release PR carries a supported label such as `release:major`.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const configPath = path.resolve(process.env.RELEASE_PLEASE_CONFIG_PATH ?? '.github/release-please-config.json');
+const manifestPath = path.resolve(process.env.RELEASE_PLEASE_MANIFEST_PATH ?? '.release-please-manifest.json');
+const outputPath = path.resolve(
+  process.env.RELEASE_PLEASE_OUTPUT_PATH ?? '.github/release-please-config.generated.json',
+);
+const override = process.env.RELEASE_PLEASE_OVERRIDE ?? '';
+
+const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+
+if (override === 'release:major') {
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const currentVersion = manifest['.'];
+
+  if (typeof currentVersion !== 'string') {
+    throw new Error('Expected the root package version to exist in .release-please-manifest.json');
+  }
+
+  const [major] = currentVersion.split('.');
+
+  if (!major || Number.isNaN(Number(major))) {
+    throw new Error(`Could not parse the current manifest version: ${currentVersion}`);
+  }
+
+  const nextMajorVersion = `${Number(major) + 1}.0.0`;
+
+  config.packages ??= {};
+  config.packages['.'] ??= {};
+  config.packages['.']['release-as'] = nextMajorVersion;
+}
+
+fs.writeFileSync(outputPath, `${JSON.stringify(config, null, 2)}\n`);


### PR DESCRIPTION
## Summary
- add a release-please override workflow that reacts to the  label on the release PR
- generate a temporary release-please config that forces the next major version when that label is present
- update the release PR title from the actual release branch package version so label add/remove keeps the title in sync

## Testing
- npm run lint
- npm run typecheck
- npm run test:coverage