### PR TITLE
fix: build package before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "vitest",
     "test:coverage": "vitest --run --coverage",
     "lint": "eslint .",
+    "prepack": "npm run build",
     "lockfile:check": "git diff --exit-code -- package-lock.json",
     "pack:smoke": "npm run build && node ./scripts/smoke-pack.mjs",
     "consumer:smoke": "npm run build && node ./scripts/smoke-consumer.mjs",


### PR DESCRIPTION
## Summary

Build the package during npm's `prepack` lifecycle so published tarballs always include `dist/`.

## Root cause

The Release Please publish job ran `npm publish` without a package lifecycle build. Because `dist/` is the only packaged directory, the canary tarball shipped without the runtime entry point.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test -- --run`
- `npm pack --dry-run` (confirmed `dist/index.js` and all compiled rule modules are included)

Fixes #25
