### PR TITLE
refactor: simplify config exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,21 +60,12 @@ module.exports = {
 
 ## Included Configs
 
-The plugin exports:
+The plugin exports two recommended configs:
 
-- `configs.default`
-- `configs.recommended`
-- `configs["flat/default"]`
-- `configs["flat/recommended"]`
-- `configs["legacy-default"]`
-- `configs["legacy-recommended"]`
-- `flat`
+- `configs.recommended` for legacy config
+- `configs["flat/recommended"]` for flat config
 
-Config behavior:
-
-- `configs.default` and `configs["legacy-default"]` enable only `no-barrel-files`
-- `configs.recommended`, `configs["flat/recommended"]`, and `configs["legacy-recommended"]` enable both rules
-- `flat` is the flat-config equivalent of the default config
+Both enable `no-barrel-files` and `prefer-source-imports`.
 
 ## Rules
 
@@ -204,14 +195,23 @@ Example:
 
 ## Configuration Examples
 
-### Use The Default Config Only
+### Enable Only `no-barrel-files`
 
 This blocks new barrel files, but does not yet enforce direct source imports.
 
 ```js
 import noBarrelFiles from 'eslint-plugin-no-barrel-files';
 
-export default [...noBarrelFiles.configs['flat/default']];
+export default [
+  {
+    plugins: {
+      'no-barrel-files': noBarrelFiles,
+    },
+    rules: {
+      'no-barrel-files/no-barrel-files': 'error',
+    },
+  },
+];
 ```
 
 ### Enable Both Rules

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -9,12 +9,6 @@ describe('plugin entrypoint', () => {
       namespace: 'no-barrel-files',
     });
 
-    expect(plugin.configs?.default).toEqual({
-      plugins: ['no-barrel-files'],
-      rules: {
-        'no-barrel-files/no-barrel-files': 'error',
-      },
-    });
     expect(plugin.configs?.recommended).toEqual({
       plugins: ['no-barrel-files'],
       rules: {
@@ -22,7 +16,6 @@ describe('plugin entrypoint', () => {
         'no-barrel-files/prefer-source-imports': 'error',
       },
     });
-    expect(plugin.configs?.['flat/default']).toEqual([plugin.flat]);
     expect(plugin.configs?.['flat/recommended']).toEqual([
       {
         plugins: {
@@ -37,8 +30,7 @@ describe('plugin entrypoint', () => {
         },
       },
     ]);
-    expect(plugin.configs?.['legacy-default']).toEqual(plugin.configs?.default);
-    expect(plugin.configs?.['legacy-recommended']).toEqual(plugin.configs?.recommended);
+    expect(Object.keys(plugin.configs ?? {})).toEqual(['recommended', 'flat/recommended']);
 
     expect(plugin.rules).toHaveProperty('prefer-source-imports');
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,29 +17,15 @@ const runtimeMeta = {
   namespace: 'no-barrel-files',
 } as const;
 
-const flatDefaultConfig = {
+const flatRecommendedConfig = {
   plugins: {
     'no-barrel-files': { meta: runtimeMeta, rules } as Omit<TSESLint.FlatConfig.Plugin, 'configs'>,
   },
   rules: {
     'no-barrel-files/no-barrel-files': 'error',
-  },
-} satisfies TSESLint.FlatConfig.Config;
-
-const flatRecommendedConfig = {
-  ...flatDefaultConfig,
-  rules: {
-    ...flatDefaultConfig.rules,
     'no-barrel-files/prefer-source-imports': 'error',
   },
 } satisfies TSESLint.FlatConfig.Config;
-
-const legacyDefaultConfig = {
-  plugins: ['no-barrel-files'],
-  rules: {
-    'no-barrel-files/no-barrel-files': 'error',
-  },
-} as const;
 
 const legacyRecommendedConfig = {
   plugins: ['no-barrel-files'],
@@ -50,22 +36,16 @@ const legacyRecommendedConfig = {
 } as const;
 
 const configs = {
-  default: legacyDefaultConfig,
   recommended: legacyRecommendedConfig,
-  'flat/default': [flatDefaultConfig],
   'flat/recommended': [flatRecommendedConfig],
-  'legacy-default': legacyDefaultConfig,
-  'legacy-recommended': legacyRecommendedConfig,
 } as const;
 
 const plugin = {
   meta: runtimeMeta,
   configs: configs as unknown as TSESLint.FlatConfig.Plugin['configs'],
   rules,
-  flat: flatDefaultConfig,
 } as unknown as TSESLint.FlatConfig.Plugin & {
   configs: typeof configs;
-  flat: TSESLint.FlatConfig.Config;
   meta: typeof runtimeMeta;
 };
 


### PR DESCRIPTION
## Summary

Reduce the public config API to the two ESLint-native recommended presets:

- `configs.recommended` for legacy config
- `configs["flat/recommended"]` for flat config

## Why

The prior API exported several aliases for the same configurations, which made the plugin surface harder to understand without adding capability.

## Notes

Users who want only `no-barrel-files` can configure that rule directly; the README includes an example.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test -- --run`
- `npm run build`
