### PR TITLE
fix: detect imports declared after exports

### DIFF
--- a/src/rules/no-barrel-files.ts
+++ b/src/rules/no-barrel-files.ts
@@ -17,56 +17,63 @@ const noBarrelFiles: TSESLint.RuleModule<MessageIds> = {
     },
   },
   create(context) {
-    const declaredImports: Array<string> = [];
-
     return {
-      ExportDefaultDeclaration(node) {
-        if (node.declaration.type === 'Identifier' && declaredImports.includes(node.declaration.name)) {
-          context.report({
-            node,
-            messageId: 'noReExport',
-            data: {
-              name: node.declaration.name,
-            },
-          });
-        }
-      },
-      ExportAllDeclaration(node) {
-        context.report({
-          node,
-          messageId: 'noExportAll',
-        });
-      },
-      ExportNamedDeclaration(node) {
-        if (node?.source?.type === 'Literal') {
-          context.report({
-            node,
-            messageId: 'noReExport',
-            data: {
-              name: node.source.value,
-            },
-          });
-        }
+      'Program:exit'(program) {
+        const declaredImports = new Set(
+          program.body.flatMap(statement =>
+            statement.type === AST_NODE_TYPES.ImportDeclaration
+              ? statement.specifiers.map(specifier => specifier.local.name)
+              : [],
+          ),
+        );
 
-        node.specifiers.forEach(specifier => {
-          if (
-            specifier.local.type === AST_NODE_TYPES.Identifier &&
-            specifier.exported.type === AST_NODE_TYPES.Identifier &&
-            declaredImports.includes(specifier.local.name)
-          ) {
+        program.body.forEach(node => {
+          if (node.type === AST_NODE_TYPES.ExportDefaultDeclaration) {
+            if (node.declaration.type === AST_NODE_TYPES.Identifier && declaredImports.has(node.declaration.name)) {
+              context.report({
+                node,
+                messageId: 'noReExport',
+                data: { name: node.declaration.name },
+              });
+            }
+
+            return;
+          }
+
+          if (node.type === AST_NODE_TYPES.ExportAllDeclaration) {
             context.report({
-              node: specifier,
+              node,
+              messageId: 'noExportAll',
+            });
+
+            return;
+          }
+
+          if (node.type !== AST_NODE_TYPES.ExportNamedDeclaration) {
+            return;
+          }
+
+          if (node.source?.type === 'Literal') {
+            context.report({
+              node,
               messageId: 'noReExport',
-              data: {
-                name: specifier.exported.name,
-              },
+              data: { name: node.source.value },
             });
           }
-        });
-      },
-      ImportDeclaration(node) {
-        node.specifiers.forEach(item => {
-          declaredImports.push(item.local.name);
+
+          node.specifiers.forEach(specifier => {
+            if (
+              specifier.local.type === AST_NODE_TYPES.Identifier &&
+              specifier.exported.type === AST_NODE_TYPES.Identifier &&
+              declaredImports.has(specifier.local.name)
+            ) {
+              context.report({
+                node: specifier,
+                messageId: 'noReExport',
+                data: { name: specifier.exported.name },
+              });
+            }
+          });
         });
       },
     };

--- a/src/rules/tests/no-barrel-files.test.ts
+++ b/src/rules/tests/no-barrel-files.test.ts
@@ -43,6 +43,13 @@ ruleTester.run('no-barrel-files', noBarrelFiles, {
     },
     {
       code: `
+      export { Foo };
+      import { Foo } from "./foo";
+      `,
+      errors: [{ messageId: 'noReExport' }],
+    },
+    {
+      code: `
       import Foo from "./foo";
       export { Foo };
       `,


### PR DESCRIPTION
## Summary

Detect imported bindings before evaluating exports, so source order cannot hide a barrel re-export.

## Root cause

The rule reported exports while traversing the module. An export that preceded its import was evaluated before the imported binding had been recorded.

## Validation

- `npm test -- --run src/rules/tests/no-barrel-files.test.ts`
- `npm run lint`
- `npm run typecheck`
