### PR TITLE
fix: derive plugin metadata version

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from 'vitest';
+import packageJson from '../package.json';
 import plugin from './index';
 
 describe('plugin entrypoint', () => {
   it('exposes ESLint 10-compatible metadata and config exports', () => {
     expect(plugin.meta).toEqual({
       name: 'eslint-plugin-no-barrel-files',
-      version: '1.4.0',
+      version: packageJson.version,
       namespace: 'no-barrel-files',
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { TSESLint } from '@typescript-eslint/utils';
+import packageJson from '../package.json';
 import noBarrelFiles from './rules/no-barrel-files';
 import preferSourceImports from './rules/prefer-source-imports';
 
@@ -9,7 +10,7 @@ const rules = {
 
 const pluginMeta = {
   name: 'eslint-plugin-no-barrel-files',
-  version: '1.4.0',
+  version: packageJson.version,
 } satisfies NonNullable<TSESLint.FlatConfig.Plugin['meta']>;
 
 const runtimeMeta = {


### PR DESCRIPTION
## Summary

Read the plugin metadata version from `package.json` instead of maintaining a duplicate hard-coded value.

## Why

Release Please updates `package.json`; deriving the runtime metadata from that file prevents the two versions from drifting apart.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test -- --run src/index.test.ts`
- `npm run build`
- `npm run pack:smoke`
