### PR TITLE
fix: resolve aliases from configured base paths

### DIFF
--- a/src/rules/prefer-source-imports/resolution.ts
+++ b/src/rules/prefer-source-imports/resolution.ts
@@ -154,9 +154,7 @@ export function resolveWithManualPaths(
     for (const target of targets) {
       const candidateSpecifier = applyAliasTarget(target, wildcardValue);
       const candidateBasePath = path.resolve(cwd, candidateSpecifier);
-      const resolvedFilePath =
-        resolveModuleFile(importerFilename, candidateSpecifier) ??
-        resolveModuleFile(importerFilename, candidateBasePath);
+      const resolvedFilePath = resolveModuleFile(importerFilename, candidateBasePath);
 
       if (resolvedFilePath) {
         return resolvedFilePath;
@@ -295,15 +293,21 @@ export function reverseResolveTsconfigAlias(
     return null;
   }
 
+  const configDirectory = path.dirname(tsconfigInfo.configFilePath);
+  const baseUrl = tsconfigInfo.compilerOptions.baseUrl;
+  const pathsBaseDirectory = baseUrl
+    ? path.isAbsolute(baseUrl)
+      ? baseUrl
+      : path.resolve(configDirectory, baseUrl)
+    : configDirectory;
+
   const candidateAliases = Object.entries(paths as Record<string, string[]>)
     .flatMap(([pattern, targets]) =>
       targets.map(target => {
         if (target.includes('*')) {
           const [rawPrefix = '', rawSuffix = ''] = target.split('*');
           const normalizedResolvedFilePath = normalizeModulePath(resolvedFilePath);
-          const normalizedPrefix = normalizeModulePath(
-            path.resolve(path.dirname(tsconfigInfo.configFilePath), rawPrefix),
-          );
+          const normalizedPrefix = normalizeModulePath(path.resolve(pathsBaseDirectory, rawPrefix));
           const normalizedSuffix = normalizeModulePath(rawSuffix);
 
           if (
@@ -321,10 +325,7 @@ export function reverseResolveTsconfigAlias(
           return buildAliasSpecifier(pattern, wildcardValue.replace(/^\//, ''));
         }
 
-        const targetFilePath = resolveModuleFile(
-          importerFilename,
-          path.resolve(path.dirname(tsconfigInfo.configFilePath), target),
-        );
+        const targetFilePath = resolveModuleFile(importerFilename, path.resolve(pathsBaseDirectory, target));
 
         return targetFilePath === resolvedFilePath ? pattern : null;
       }),

--- a/src/rules/tests/prefer-source-imports.helpers.test.ts
+++ b/src/rules/tests/prefer-source-imports.helpers.test.ts
@@ -613,6 +613,8 @@ describe('prefer-source-imports private helpers', () => {
     writeFiles(tempDir, {
       'src/foo.ts': 'export const Foo = 1;',
       'src/index.ts': 'export const Index = 1;',
+      'nested/src/foo.ts': 'export const ShadowedFoo = 1;',
+      'packages/app/src/foo.ts': 'export const BaseUrlFoo = 1;',
       'tsconfig.json': JSON.stringify(
         {
           compilerOptions: {
@@ -642,6 +644,18 @@ describe('prefer-source-imports private helpers', () => {
             baseUrl: '.',
             paths: {
               '@exact': ['src/foo'],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      'tsconfig-base-url.json': JSON.stringify(
+        {
+          compilerOptions: {
+            baseUrl: './packages/app',
+            paths: {
+              '@base/*': ['src/*'],
             },
           },
         },
@@ -688,6 +702,14 @@ describe('prefer-source-imports private helpers', () => {
     expect(__private__.resolveWithManualPaths(options, importer, '@manual/foo', tempDir)).toBe(
       path.join(tempDir, 'src/foo.ts'),
     );
+    expect(
+      __private__.resolveWithManualPaths(
+        { paths: { '@manual/*': 'src/*' } },
+        path.join(tempDir, 'nested/consumer.ts'),
+        '@manual/foo',
+        tempDir,
+      ),
+    ).toBe(path.join(tempDir, 'src/foo.ts'));
     expect(__private__.resolveWithManualPaths(options, importer, '@missing/foo', tempDir)).toBeNull();
 
     expect(__private__.getTsconfigPath({ tsconfig: false }, importer, tempDir)).toBeNull();
@@ -708,6 +730,15 @@ describe('prefer-source-imports private helpers', () => {
       path.join(tempDir, 'src/foo.ts'),
     );
     expect(__private__.resolveWithTsconfig({ tsconfig: false }, importer, '@app/foo', new Map(), tempDir)).toBeNull();
+    expect(
+      __private__.resolveWithTsconfig(
+        { tsconfig: path.join(tempDir, 'tsconfig-base-url.json') },
+        importer,
+        '@base/foo',
+        new Map(),
+        tempDir,
+      ),
+    ).toBe(path.join(tempDir, 'packages/app/src/foo.ts'));
 
     expect(__private__.resolveImport({}, resolutionCaches, importer, './src/foo', tempDir)).toBe(
       path.join(tempDir, 'src/foo.ts'),
@@ -744,6 +775,15 @@ describe('prefer-source-imports private helpers', () => {
         tempDir,
       ),
     ).toBeNull();
+    expect(
+      __private__.reverseResolveTsconfigAlias(
+        { tsconfig: path.join(tempDir, 'tsconfig-base-url.json') },
+        importer,
+        path.join(tempDir, 'packages/app/src/foo.ts'),
+        new Map(),
+        tempDir,
+      ),
+    ).toBe('@base/foo');
     expect(
       __private__.reverseResolveTsconfigAlias(
         { tsconfig: path.join(tempDir, 'tsconfig-no-paths.json') },
@@ -809,6 +849,22 @@ describe('prefer-source-imports private helpers', () => {
     );
 
     expect(tsAlias).toBe('./src/foo');
+    expect(
+      __private__.getPreferredSourceSpecifier(
+        { fixStyle: 'preserve-alias', tsconfig: path.join(tempDir, 'tsconfig-base-url.json') },
+        importer,
+        '@base/barrel',
+        {
+          importedName: 'Foo',
+          resolvedFilePath: path.join(tempDir, 'packages/app/src/foo.ts'),
+          sourceSpecifier: './foo',
+          isTypeOnly: false,
+          fromExportAll: false,
+        },
+        new Map(),
+        tempDir,
+      ),
+    ).toBe('@base/foo');
     expect(
       __private__.getPreferredSourceSpecifier(
         {},

--- a/src/rules/tests/prefer-source-imports.helpers.test.ts
+++ b/src/rules/tests/prefer-source-imports.helpers.test.ts
@@ -662,6 +662,17 @@ describe('prefer-source-imports private helpers', () => {
         null,
         2,
       ),
+      'tsconfig-paths-without-base-url.json': JSON.stringify(
+        {
+          compilerOptions: {
+            paths: {
+              '@config/*': ['src/*'],
+            },
+          },
+        },
+        null,
+        2,
+      ),
       'tsconfig-duplicate.json': JSON.stringify(
         {
           compilerOptions: {
@@ -784,6 +795,36 @@ describe('prefer-source-imports private helpers', () => {
         tempDir,
       ),
     ).toBe('@base/foo');
+    expect(
+      __private__.reverseResolveTsconfigAlias(
+        { tsconfig: path.join(tempDir, 'tsconfig-paths-without-base-url.json') },
+        importer,
+        path.join(tempDir, 'src/foo.ts'),
+        new Map(),
+        tempDir,
+      ),
+    ).toBe('@config/foo');
+    const relativeBaseUrlConfigPath = path.join(tempDir, 'tsconfig-relative-base-url.json');
+    expect(
+      __private__.reverseResolveTsconfigAlias(
+        { tsconfig: relativeBaseUrlConfigPath },
+        importer,
+        path.join(tempDir, 'packages/app/src/foo.ts'),
+        new Map([
+          [
+            relativeBaseUrlConfigPath,
+            {
+              compilerOptions: {
+                baseUrl: 'packages/app',
+                paths: { '@relative/*': ['src/*'] },
+              },
+              configFilePath: relativeBaseUrlConfigPath,
+            },
+          ],
+        ]),
+        tempDir,
+      ),
+    ).toBe('@relative/foo');
     expect(
       __private__.reverseResolveTsconfigAlias(
         { tsconfig: path.join(tempDir, 'tsconfig-no-paths.json') },


### PR DESCRIPTION
## Summary
- resolve manual path aliases relative to the configured working directory
- honor TypeScript `baseUrl` when reverse-mapping paths aliases
- add regressions for alias shadowing and non-root base URLs

## Root cause
Manual mappings were tried relative to the importing file before their configured cwd target. Reverse tsconfig alias matching used the config directory instead of `compilerOptions.baseUrl`.

## Validation
- npm test -- --run
- npm run lint
- npm run typecheck
- git diff --check