### PR TITLE
feat: resolve local re-export barrels

### DIFF
--- a/src/rules/prefer-source-imports/analysis.ts
+++ b/src/rules/prefer-source-imports/analysis.ts
@@ -344,6 +344,48 @@ export function collectBarrelAnalysis(
 ): BarrelAnalysis | null {
   const explicitReExports = new Map<string, ReExportTarget>();
   const exportAllReExports = new Map<string, ReExportTarget>();
+  const importedBindings = new Map<
+    string,
+    { importedName: string; isTypeOnly: boolean; resolvedFilePath: string; sourceSpecifier: string }
+  >();
+
+  program.body.forEach(statement => {
+    if (
+      statement.type !== AST_NODE_TYPES.ImportDeclaration ||
+      statement.source.type !== AST_NODE_TYPES.Literal ||
+      typeof statement.source.value !== 'string'
+    ) {
+      return;
+    }
+
+    const resolvedSourceFile = resolveImport(barrelFilePath, statement.source.value);
+
+    if (!resolvedSourceFile) {
+      return;
+    }
+
+    statement.specifiers.forEach(specifier => {
+      const importedName =
+        specifier.type === AST_NODE_TYPES.ImportDefaultSpecifier
+          ? 'default'
+          : specifier.type === AST_NODE_TYPES.ImportSpecifier && specifier.imported.type === AST_NODE_TYPES.Identifier
+            ? specifier.imported.name
+            : null;
+
+      if (!importedName) {
+        return;
+      }
+
+      importedBindings.set(specifier.local.name, {
+        importedName,
+        isTypeOnly:
+          statement.importKind === 'type' ||
+          (specifier.type === AST_NODE_TYPES.ImportSpecifier && specifier.importKind === 'type'),
+        resolvedFilePath: resolvedSourceFile,
+        sourceSpecifier: statement.source.value,
+      });
+    });
+  });
 
   program.body.forEach(statement => {
     const source = statement.type === AST_NODE_TYPES.ExportNamedDeclaration ? statement.source : null;
@@ -400,6 +442,65 @@ export function collectBarrelAnalysis(
         });
 
         if (!specifierIsTypeOnly && sourceExportedBindings.has(getReExportKey(specifier.local.name, true))) {
+          explicitReExports.set(getReExportKey(specifier.exported.name, true), {
+            importedName: resolvedTarget.importedName,
+            resolvedFilePath: resolvedTarget.resolvedFilePath,
+            sourceSpecifier: resolvedTarget.sourceSpecifier,
+            isTypeOnly: true,
+            fromExportAll: false,
+          });
+        }
+      });
+    }
+
+    if (statement.type === AST_NODE_TYPES.ExportNamedDeclaration && !statement.source) {
+      statement.specifiers.forEach(specifier => {
+        if (
+          specifier.type !== AST_NODE_TYPES.ExportSpecifier ||
+          specifier.local.type !== AST_NODE_TYPES.Identifier ||
+          specifier.exported.type !== AST_NODE_TYPES.Identifier
+        ) {
+          return;
+        }
+
+        const importedBinding = importedBindings.get(specifier.local.name);
+        const specifierIsTypeOnly = statement.exportKind === 'type' || specifier.exportKind === 'type';
+
+        if (!importedBinding || (importedBinding.isTypeOnly && !specifierIsTypeOnly)) {
+          return;
+        }
+
+        const sourceExportedBindings = parseExportedBindings(importedBinding.resolvedFilePath, analysisCaches);
+        const resolvedTarget =
+          resolveReExportTarget(
+            importedBinding.resolvedFilePath,
+            importedBinding.importedName,
+            specifierIsTypeOnly,
+            resolveImport,
+            analysisCaches,
+            visitedTargets,
+          ) ??
+          ({
+            importedName: importedBinding.importedName,
+            resolvedFilePath: importedBinding.resolvedFilePath,
+            sourceSpecifier: importedBinding.sourceSpecifier,
+            isTypeOnly: specifierIsTypeOnly,
+            fromExportAll: false,
+          } satisfies ReExportTarget);
+
+        if (resolvedTarget.resolvedFilePath === barrelFilePath) {
+          return;
+        }
+
+        explicitReExports.set(getReExportKey(specifier.exported.name, specifierIsTypeOnly), {
+          importedName: resolvedTarget.importedName,
+          resolvedFilePath: resolvedTarget.resolvedFilePath,
+          sourceSpecifier: resolvedTarget.sourceSpecifier,
+          isTypeOnly: specifierIsTypeOnly,
+          fromExportAll: false,
+        });
+
+        if (!specifierIsTypeOnly && sourceExportedBindings.has(getReExportKey(importedBinding.importedName, true))) {
           explicitReExports.set(getReExportKey(specifier.exported.name, true), {
             importedName: resolvedTarget.importedName,
             resolvedFilePath: resolvedTarget.resolvedFilePath,

--- a/src/rules/tests/fixtures/prefer-source-imports/local-barrel-invalid-type.ts
+++ b/src/rules/tests/fixtures/prefer-source-imports/local-barrel-invalid-type.ts
@@ -1,0 +1,3 @@
+import type { TypeFoo } from './types';
+
+export { TypeFoo };

--- a/src/rules/tests/fixtures/prefer-source-imports/local-barrel-namespace.ts
+++ b/src/rules/tests/fixtures/prefer-source-imports/local-barrel-namespace.ts
@@ -1,0 +1,3 @@
+import * as LocalNamespace from './foo';
+
+export { LocalNamespace };

--- a/src/rules/tests/fixtures/prefer-source-imports/local-barrel-self.ts
+++ b/src/rules/tests/fixtures/prefer-source-imports/local-barrel-self.ts
@@ -1,0 +1,3 @@
+import { LocalSelf } from './local-barrel-self';
+
+export { LocalSelf };

--- a/src/rules/tests/fixtures/prefer-source-imports/local-barrel-unresolved.ts
+++ b/src/rules/tests/fixtures/prefer-source-imports/local-barrel-unresolved.ts
@@ -1,0 +1,3 @@
+import { Missing } from './missing';
+
+export { Missing };

--- a/src/rules/tests/fixtures/prefer-source-imports/local-barrel-value.ts
+++ b/src/rules/tests/fixtures/prefer-source-imports/local-barrel-value.ts
@@ -1,0 +1,1 @@
+export const LocalValue = 1;

--- a/src/rules/tests/fixtures/prefer-source-imports/local-barrel.ts
+++ b/src/rules/tests/fixtures/prefer-source-imports/local-barrel.ts
@@ -1,0 +1,11 @@
+import DefaultThing from './default-thing';
+import { ClassThing as LocalClassThing } from './class-thing';
+import { Foo as LocalFoo } from './foo';
+import { RecursiveFoo as LocalRecursiveFoo } from './recursive-barrel';
+import type { TypeFoo as LocalTypeFoo } from './types';
+
+export { DefaultThing as LocalDefaultThing };
+export { LocalClassThing };
+export { LocalFoo };
+export { LocalRecursiveFoo };
+export type { LocalTypeFoo };

--- a/src/rules/tests/prefer-source-imports.helpers.test.ts
+++ b/src/rules/tests/prefer-source-imports.helpers.test.ts
@@ -510,6 +510,32 @@ describe('prefer-source-imports private helpers', () => {
     const program = {
       body: [
         {
+          type: AST_NODE_TYPES.ImportDeclaration,
+          importKind: 'value',
+          source: { type: AST_NODE_TYPES.Literal, value: './value' },
+          specifiers: [
+            {
+              type: AST_NODE_TYPES.ImportSpecifier,
+              importKind: 'value',
+              imported: { type: AST_NODE_TYPES.Identifier, name: 'Foo' },
+              local: { type: AST_NODE_TYPES.Identifier, name: 'LocalFoo' },
+            },
+          ],
+        },
+        {
+          type: AST_NODE_TYPES.ExportNamedDeclaration,
+          exportKind: 'value',
+          source: null,
+          specifiers: [
+            {
+              type: AST_NODE_TYPES.ExportSpecifier,
+              exportKind: 'value',
+              exported: { type: AST_NODE_TYPES.Literal, value: 'SkippedLocal' },
+              local: { type: AST_NODE_TYPES.Identifier, name: 'LocalFoo' },
+            },
+          ],
+        },
+        {
           type: AST_NODE_TYPES.ExportNamedDeclaration,
           exportKind: 'value',
           source: { type: AST_NODE_TYPES.Literal, value: './missing-explicit' },

--- a/src/rules/tests/prefer-source-imports.test.ts
+++ b/src/rules/tests/prefer-source-imports.test.ts
@@ -19,6 +19,26 @@ ruleTester.run('prefer-source-imports', preferSourceImports, {
       code: `import { Missing } from './barrel';`,
       filename: path.join(fixtureDirectory, 'consumer.ts'),
     },
+    {
+      code: `import { LocalValue } from './local-barrel-value';`,
+      filename: path.join(fixtureDirectory, 'consumer.ts'),
+    },
+    {
+      code: `import { Missing } from './local-barrel-unresolved';`,
+      filename: path.join(fixtureDirectory, 'consumer.ts'),
+    },
+    {
+      code: `import { LocalSelf } from './local-barrel-self';`,
+      filename: path.join(fixtureDirectory, 'consumer.ts'),
+    },
+    {
+      code: `import { TypeFoo } from './local-barrel-invalid-type';`,
+      filename: path.join(fixtureDirectory, 'consumer.ts'),
+    },
+    {
+      code: `import { LocalNamespace } from './local-barrel-namespace';`,
+      filename: path.join(fixtureDirectory, 'consumer.ts'),
+    },
   ],
   invalid: [
     {
@@ -70,6 +90,36 @@ ruleTester.run('prefer-source-imports', preferSourceImports, {
       code: `import { Baz } from './barrel';`,
       filename: path.join(fixtureDirectory, 'consumer.ts'),
       output: `import { Bar as Baz } from './bar';`,
+      errors: [{ messageId: 'preferSourceImports' }],
+    },
+    {
+      code: `import { LocalFoo } from './local-barrel';`,
+      filename: path.join(fixtureDirectory, 'consumer.ts'),
+      output: `import { Foo as LocalFoo } from './foo';`,
+      errors: [{ messageId: 'preferSourceImports' }],
+    },
+    {
+      code: `import { LocalDefaultThing } from './local-barrel';`,
+      filename: path.join(fixtureDirectory, 'consumer.ts'),
+      output: `import { default as LocalDefaultThing } from './default-thing';`,
+      errors: [{ messageId: 'preferSourceImports' }],
+    },
+    {
+      code: `import type { LocalTypeFoo } from './local-barrel';`,
+      filename: path.join(fixtureDirectory, 'consumer.ts'),
+      output: `import type { TypeFoo as LocalTypeFoo } from './types';`,
+      errors: [{ messageId: 'preferSourceImports' }],
+    },
+    {
+      code: `import type { LocalClassThing } from './local-barrel';`,
+      filename: path.join(fixtureDirectory, 'consumer.ts'),
+      output: `import type { ClassThing as LocalClassThing } from './class-thing';`,
+      errors: [{ messageId: 'preferSourceImports' }],
+    },
+    {
+      code: `import { LocalRecursiveFoo } from './local-barrel';`,
+      filename: path.join(fixtureDirectory, 'consumer.ts'),
+      output: `import { RecursiveFoo as LocalRecursiveFoo } from './recursive-foo';`,
       errors: [{ messageId: 'preferSourceImports' }],
     },
     {


### PR DESCRIPTION
## Summary
- resolve named, default, and type-only imports re-exported through local bindings
- follow those re-exports recursively through nested barrels
- add coverage for safe no-op cases: unresolved sources, cycles, namespace imports, and local values

## Why
The migration rule previously recognized only direct `export … from` and star re-exports, missing the common `import …; export { … }` barrel pattern.

## Validation
- npm run test:coverage
- npm run lint
- npm run typecheck
- git diff --check