### PR TITLE
feat: support TypeScript 6

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -47,6 +47,24 @@ jobs:
       - run: npm ci --include=dev
       - run: npm run test:coverage
 
+  typescript-compatibility:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        typescript-version: ['5.6.3', '6.0.3']
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci --include=dev
+      - run: npm install --no-save --package-lock=false typescript@${{ matrix.typescript-version }}
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm test -- --run
+
   consumer-smoke:
     runs-on: ubuntu-latest
     strategy:

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,13 +22,13 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",
         "globals": "^15.12.0",
-        "typescript": "^5.6.3",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.58.1",
         "vitest": "^4.1.4"
       },
       "peerDependencies": {
         "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0",
-        "typescript": "^5.6.3"
+        "typescript": "^5.6.3 || ^6.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2467,9 +2467,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4188,9 +4188,9 @@
       }
     },
     "typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="
     },
     "typescript-eslint": {
       "version": "8.58.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "globals": "^15.12.0",
-    "typescript": "^5.6.3",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.58.1",
     "vitest": "^4.1.4"
   },
@@ -52,7 +52,7 @@
   },
   "peerDependencies": {
     "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3 || ^6.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "strict": true,
     "outDir": "dist",
     "sourceMap": true,


### PR DESCRIPTION
## Summary
- widen the optional TypeScript peer range through TypeScript 6
- use TypeScript 6.0.3 for development and validation
- test the supported TypeScript 5.6 and 6.0 compiler lines in CI
- remove the obsolete root `baseUrl` setting that TypeScript 6 rejects

## Why
The plugin uses TypeScript compiler APIs for tsconfig and module resolution. TypeScript 6 retains that API, but the previous peer range prevented consumer installation.

TypeScript 7.0 is intentionally excluded because it does not ship a programmatic compiler API; #38 tracks support once the TypeScript 7.1 API is available.

## Validation
- npm ci --include=dev
- npm run test:coverage (100%)
- npm run lint
- npm run typecheck
- TypeScript 5.6.3: lint, typecheck, tests
- git diff --check