### PR TITLE
perf: speed up TypeScript import resolution

### DIFF
--- a/src/rules/prefer-source-imports.ts
+++ b/src/rules/prefer-source-imports.ts
@@ -29,6 +29,7 @@ import {
 } from './prefer-source-imports/path-utils';
 import {
   createResolutionCaches,
+  createSharedResolutionCaches,
   getBarrelAnalysis,
   getManualAliasMappings,
   getPreferredSourceSpecifier,
@@ -111,7 +112,7 @@ const preferSourceImports: TSESLint.RuleModule<MessageIds, Options> = {
     const sourceCode = context.sourceCode;
     const barrelExportCache = new Map<string, BarrelAnalysis | null>();
     const analysisCaches = createAnalysisCaches();
-    const resolutionCaches = createResolutionCaches();
+    const resolutionCaches = createSharedResolutionCaches();
     const cwd = process.cwd();
     const missingTypeScript = shouldReportMissingTypeScript(context.filename, options);
 
@@ -177,6 +178,7 @@ const preferSourceImports: TSESLint.RuleModule<MessageIds, Options> = {
                 explicitReExport,
                 resolutionCaches.tsconfigInfo,
                 cwd,
+                resolutionCaches.tsconfigPaths,
               ),
               specifier,
               reExportTarget: explicitReExport,
@@ -198,6 +200,7 @@ const preferSourceImports: TSESLint.RuleModule<MessageIds, Options> = {
               exportAllReExport,
               resolutionCaches.tsconfigInfo,
               cwd,
+              resolutionCaches.tsconfigPaths,
             ),
             specifier,
             reExportTarget: exportAllReExport,
@@ -242,6 +245,7 @@ const preferSourceImports: TSESLint.RuleModule<MessageIds, Options> = {
                   reExportTarget,
                   resolutionCaches.tsconfigInfo,
                   cwd,
+                  resolutionCaches.tsconfigPaths,
                 ) ?? reExportTarget.sourceSpecifier,
             },
           });
@@ -260,6 +264,7 @@ export const __private__ = {
   collectExportedBindings,
   createAnalysisCaches,
   createResolutionCaches,
+  createSharedResolutionCaches,
   getBarrelAnalysis,
   getManualAliasMappings,
   getTypeScriptModule,

--- a/src/rules/prefer-source-imports.ts
+++ b/src/rules/prefer-source-imports.ts
@@ -140,6 +140,12 @@ const preferSourceImports: TSESLint.RuleModule<MessageIds, Options> = {
           return;
         }
 
+        const namedSpecifiers = node.specifiers.filter(isNamedImportSpecifier);
+
+        if (namedSpecifiers.length === 0) {
+          return;
+        }
+
         const importerFilename = context.filename;
         const barrelFilePath = resolveImport(options, resolutionCaches, importerFilename, node.source.value, cwd);
 
@@ -157,12 +163,6 @@ const preferSourceImports: TSESLint.RuleModule<MessageIds, Options> = {
         );
 
         if (!barrelAnalysis) {
-          return;
-        }
-
-        const namedSpecifiers = node.specifiers.filter(isNamedImportSpecifier);
-
-        if (namedSpecifiers.length === 0) {
           return;
         }
 

--- a/src/rules/prefer-source-imports.ts
+++ b/src/rules/prefer-source-imports.ts
@@ -64,6 +64,10 @@ function shouldReportMissingTypeScript(_filename: string, options: Options[0] | 
   return options?.tsconfig !== false && !hasTypeScriptModule();
 }
 
+// ESLint creates a rule instance for every file. Parsed barrel modules are
+// immutable for this rule's fixes, so share them across those instances.
+const sharedAnalysisCaches = createAnalysisCaches();
+
 const preferSourceImports: TSESLint.RuleModule<MessageIds, Options> = {
   defaultOptions: [{}],
   meta: {
@@ -111,7 +115,7 @@ const preferSourceImports: TSESLint.RuleModule<MessageIds, Options> = {
     const [options] = context.options;
     const sourceCode = context.sourceCode;
     const barrelExportCache = new Map<string, BarrelAnalysis | null>();
-    const analysisCaches = createAnalysisCaches();
+    const analysisCaches = sharedAnalysisCaches;
     const resolutionCaches = createSharedResolutionCaches();
     const cwd = process.cwd();
     const missingTypeScript = shouldReportMissingTypeScript(context.filename, options);

--- a/src/rules/prefer-source-imports/resolution.ts
+++ b/src/rules/prefer-source-imports/resolution.ts
@@ -36,6 +36,7 @@ let loadTypeScriptModule: () => TypeScriptModule | null = () => {
 
 const sharedTsconfigCache = new Map<string, TsconfigInfo | null>();
 const sharedTsconfigPathCache = new Map<string, string | null>();
+const sharedBarrelAnalysisCache = new Map<string, BarrelAnalysis | null>();
 
 export function createResolutionCaches(
   sharedTsconfigCache: Map<string, TsconfigInfo | null> = new Map<string, TsconfigInfo | null>(),
@@ -50,12 +51,16 @@ export function createResolutionCaches(
 }
 
 export function createSharedResolutionCaches(): ResolutionCaches {
-  return createResolutionCaches(sharedTsconfigCache, sharedTsconfigPathCache);
+  return {
+    ...createResolutionCaches(sharedTsconfigCache, sharedTsconfigPathCache),
+    barrelAnalyses: sharedBarrelAnalysisCache,
+  };
 }
 
 export function setTypeScriptModuleLoaderForTests(loader: (() => TypeScriptModule | null) | null): void {
   sharedTsconfigCache.clear();
   sharedTsconfigPathCache.clear();
+  sharedBarrelAnalysisCache.clear();
 
   loadTypeScriptModule =
     loader ??
@@ -195,6 +200,29 @@ export function resolveWithManualPaths(
   return null;
 }
 
+function resolveWithBaseUrl(importerFilename: string, specifier: string, tsconfigInfo: TsconfigInfo): string | null {
+  const baseUrl = tsconfigInfo.compilerOptions.baseUrl;
+
+  if (!baseUrl) {
+    return null;
+  }
+
+  const configDirectory = path.dirname(tsconfigInfo.configFilePath);
+  const baseUrlDirectory = path.isAbsolute(baseUrl) ? baseUrl : path.resolve(configDirectory, baseUrl);
+
+  return resolveModuleFile(importerFilename, path.resolve(baseUrlDirectory, specifier));
+}
+
+function hasMatchingTsconfigPath(specifier: string, tsconfigInfo: TsconfigInfo): boolean {
+  const paths = tsconfigInfo.compilerOptions.paths;
+
+  return (
+    !!paths &&
+    typeof paths === 'object' &&
+    Object.keys(paths).some(pattern => matchesAliasPattern(specifier, pattern) !== null)
+  );
+}
+
 export function getManualAliasMappings(options: Options[0] | undefined): Array<ManualAliasMapping> {
   const configuredPaths = options?.paths;
 
@@ -227,6 +255,16 @@ export function resolveWithTsconfig(
   const tsconfigInfo = getTsconfigInfo(options, importerFilename, tsconfigCache, cwd, tsconfigPathCache);
 
   if (!tsconfigInfo) {
+    return null;
+  }
+
+  const baseUrlResolution = resolveWithBaseUrl(importerFilename, specifier, tsconfigInfo);
+
+  if (baseUrlResolution) {
+    return baseUrlResolution;
+  }
+
+  if (!hasMatchingTsconfigPath(specifier, tsconfigInfo)) {
     return null;
   }
 

--- a/src/rules/prefer-source-imports/resolution.ts
+++ b/src/rules/prefer-source-imports/resolution.ts
@@ -34,17 +34,29 @@ let loadTypeScriptModule: () => TypeScriptModule | null = () => {
   }
 };
 
+const sharedTsconfigCache = new Map<string, TsconfigInfo | null>();
+const sharedTsconfigPathCache = new Map<string, string | null>();
+
 export function createResolutionCaches(
   sharedTsconfigCache: Map<string, TsconfigInfo | null> = new Map<string, TsconfigInfo | null>(),
+  sharedTsconfigPathCache: Map<string, string | null> = new Map<string, string | null>(),
 ): ResolutionCaches {
   return {
     barrelAnalyses: new Map<string, BarrelAnalysis | null>(),
     importResolutions: new Map<string, string | null>(),
     tsconfigInfo: sharedTsconfigCache,
+    tsconfigPaths: sharedTsconfigPathCache,
   };
 }
 
+export function createSharedResolutionCaches(): ResolutionCaches {
+  return createResolutionCaches(sharedTsconfigCache, sharedTsconfigPathCache);
+}
+
 export function setTypeScriptModuleLoaderForTests(loader: (() => TypeScriptModule | null) | null): void {
+  sharedTsconfigCache.clear();
+  sharedTsconfigPathCache.clear();
+
   loadTypeScriptModule =
     loader ??
     (() => {
@@ -70,6 +82,7 @@ export function getTsconfigPath(
   options: Options[0] | undefined,
   importerFilename: string,
   cwd: string = process.cwd(),
+  tsconfigPathCache: Map<string, string | null> = new Map<string, string | null>(),
 ): string | null {
   const typescript = getTypeScriptModule();
 
@@ -85,7 +98,18 @@ export function getTsconfigPath(
     return path.isAbsolute(options.tsconfig) ? options.tsconfig : path.resolve(cwd, options.tsconfig);
   }
 
-  return typescript.findConfigFile(path.dirname(importerFilename), typescript.sys.fileExists, 'tsconfig.json') ?? null;
+  const importerDirectory = path.dirname(importerFilename);
+  const cacheKey = `${getOptionsCacheKey(options, cwd)}\0${importerDirectory}`;
+  const cachedPath = tsconfigPathCache.get(cacheKey);
+
+  if (cachedPath !== undefined) {
+    return cachedPath;
+  }
+
+  const tsconfigPath = typescript.findConfigFile(importerDirectory, typescript.sys.fileExists, 'tsconfig.json') ?? null;
+  tsconfigPathCache.set(cacheKey, tsconfigPath);
+
+  return tsconfigPath;
 }
 
 export function getTsconfigInfo(
@@ -93,6 +117,7 @@ export function getTsconfigInfo(
   importerFilename: string,
   tsconfigCache: Map<string, TsconfigInfo | null>,
   cwd: string = process.cwd(),
+  tsconfigPathCache: Map<string, string | null> = new Map<string, string | null>(),
 ): TsconfigInfo | null {
   const typescript = getTypeScriptModule();
 
@@ -100,7 +125,7 @@ export function getTsconfigInfo(
     return null;
   }
 
-  const tsconfigPath = getTsconfigPath(options, importerFilename, cwd);
+  const tsconfigPath = getTsconfigPath(options, importerFilename, cwd, tsconfigPathCache);
 
   if (!tsconfigPath) {
     return null;
@@ -123,6 +148,11 @@ export function getTsconfigInfo(
       tsconfigCache.set(tsconfigPath, {
         compilerOptions: parsedConfig.options,
         configFilePath: tsconfigPath,
+        moduleResolutionCache: typescript.createModuleResolutionCache(
+          path.dirname(tsconfigPath),
+          typescript.sys.useCaseSensitiveFileNames ? fileName => fileName : fileName => fileName.toLowerCase(),
+          parsedConfig.options,
+        ),
       });
     }
   }
@@ -186,6 +216,7 @@ export function resolveWithTsconfig(
   specifier: string,
   tsconfigCache: Map<string, TsconfigInfo | null>,
   cwd: string = process.cwd(),
+  tsconfigPathCache: Map<string, string | null> = new Map<string, string | null>(),
 ): string | null {
   const typescript = getTypeScriptModule();
 
@@ -193,7 +224,7 @@ export function resolveWithTsconfig(
     return null;
   }
 
-  const tsconfigInfo = getTsconfigInfo(options, importerFilename, tsconfigCache, cwd);
+  const tsconfigInfo = getTsconfigInfo(options, importerFilename, tsconfigCache, cwd, tsconfigPathCache);
 
   if (!tsconfigInfo) {
     return null;
@@ -204,6 +235,7 @@ export function resolveWithTsconfig(
     importerFilename,
     tsconfigInfo.compilerOptions,
     typescript.sys,
+    tsconfigInfo.moduleResolutionCache,
   ).resolvedModule;
 
   if (!resolvedModule || resolvedModule.isExternalLibraryImport) {
@@ -230,7 +262,14 @@ export function resolveImport(
   const resolvedFilePath = isRelativePath(specifier)
     ? resolveModuleFile(importerFilename, specifier)
     : (resolveWithManualPaths(options, importerFilename, specifier, cwd) ??
-      resolveWithTsconfig(options, importerFilename, specifier, resolutionCaches.tsconfigInfo, cwd));
+      resolveWithTsconfig(
+        options,
+        importerFilename,
+        specifier,
+        resolutionCaches.tsconfigInfo,
+        cwd,
+        resolutionCaches.tsconfigPaths,
+      ));
 
   resolutionCaches.importResolutions.set(cacheKey, resolvedFilePath);
 
@@ -280,8 +319,9 @@ export function reverseResolveTsconfigAlias(
   resolvedFilePath: string,
   tsconfigCache: Map<string, TsconfigInfo | null>,
   cwd: string = process.cwd(),
+  tsconfigPathCache: Map<string, string | null> = new Map<string, string | null>(),
 ): string | null {
-  const tsconfigInfo = getTsconfigInfo(options, importerFilename, tsconfigCache, cwd);
+  const tsconfigInfo = getTsconfigInfo(options, importerFilename, tsconfigCache, cwd, tsconfigPathCache);
 
   if (!tsconfigInfo) {
     return null;
@@ -342,6 +382,7 @@ export function getPreferredSourceSpecifier(
   reExportTarget: ReExportTarget,
   tsconfigCache: Map<string, TsconfigInfo | null>,
   cwd: string = process.cwd(),
+  tsconfigPathCache: Map<string, string | null> = new Map<string, string | null>(),
 ): string | null {
   const fixStyle = options?.fixStyle ?? 'auto';
 
@@ -355,7 +396,14 @@ export function getPreferredSourceSpecifier(
 
   const aliasCandidates = [
     reverseResolveManualAlias(options, reExportTarget.resolvedFilePath, cwd),
-    reverseResolveTsconfigAlias(options, importerFilename, reExportTarget.resolvedFilePath, tsconfigCache, cwd),
+    reverseResolveTsconfigAlias(
+      options,
+      importerFilename,
+      reExportTarget.resolvedFilePath,
+      tsconfigCache,
+      cwd,
+      tsconfigPathCache,
+    ),
   ].filter((value): value is string => value !== null);
   const uniqueAliasCandidates = Array.from(new Set(aliasCandidates));
 

--- a/src/rules/prefer-source-imports/types.ts
+++ b/src/rules/prefer-source-imports/types.ts
@@ -1,5 +1,5 @@
 import { TSESTree } from '@typescript-eslint/utils';
-import type { CompilerOptions } from 'typescript';
+import type { CompilerOptions, ModuleResolutionCache } from 'typescript';
 
 export type MessageIds = 'missingTypeScript' | 'preferSourceImport' | 'preferSourceImports';
 
@@ -43,12 +43,14 @@ export type AnalysisCaches = {
 export type TsconfigInfo = {
   compilerOptions: CompilerOptions;
   configFilePath: string;
+  moduleResolutionCache: ModuleResolutionCache;
 };
 
 export type ResolutionCaches = {
   barrelAnalyses: Map<string, BarrelAnalysis | null>;
   importResolutions: Map<string, string | null>;
   tsconfigInfo: Map<string, TsconfigInfo | null>;
+  tsconfigPaths: Map<string, string | null>;
 };
 
 export type ManualAliasMapping = {

--- a/src/rules/tests/prefer-source-imports.helpers.test.ts
+++ b/src/rules/tests/prefer-source-imports.helpers.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import * as parser from '@typescript-eslint/parser';
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import * as typescript from 'typescript';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import preferSourceImports, { __private__ } from '../prefer-source-imports';
 
@@ -111,6 +112,40 @@ describe('prefer-source-imports private helpers', () => {
     expect(__private__.shouldReportMissingTypeScript('/repo/src/file.tsx', {})).toBe(false);
     expect(__private__.getTsconfigPath({ tsconfig: false }, '/repo/src/file.ts')).toBeNull();
     expect(__private__.getTsconfigPath({}, '/repo/src/file.ts')).toBeNull();
+  });
+
+  it('shares TypeScript configuration caches across rule instances', () => {
+    const tempDir = makeTempDir();
+    const importer = path.join(tempDir, 'consumer.ts');
+
+    writeFiles(tempDir, {
+      'consumer.ts': "import { Foo } from '@app/foo';",
+      'src/foo.ts': 'export const Foo = 1;',
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          baseUrl: '.',
+          paths: {
+            '@app/*': ['src/*'],
+          },
+        },
+      }),
+    });
+
+    const findConfigFile = vi.fn(typescript.findConfigFile);
+    __private__.setTypeScriptModuleLoaderForTests(() => ({ ...typescript, findConfigFile }) as any);
+
+    const firstCaches = __private__.createSharedResolutionCaches();
+    const secondCaches = __private__.createSharedResolutionCaches();
+
+    expect(__private__.resolveImport({}, firstCaches, importer, '@app/foo', tempDir)).toBe(
+      path.join(tempDir, 'src/foo.ts'),
+    );
+    expect(__private__.resolveImport({}, secondCaches, importer, '@app/foo', tempDir)).toBe(
+      path.join(tempDir, 'src/foo.ts'),
+    );
+    expect(firstCaches.tsconfigInfo).toBe(secondCaches.tsconfigInfo);
+    expect(firstCaches.tsconfigPaths).toBe(secondCaches.tsconfigPaths);
+    expect(findConfigFile).toHaveBeenCalledTimes(1);
   });
 
   it('covers parseModule read and parse failures', () => {

--- a/src/rules/tests/prefer-source-imports.helpers.test.ts
+++ b/src/rules/tests/prefer-source-imports.helpers.test.ts
@@ -811,6 +811,25 @@ describe('prefer-source-imports private helpers', () => {
         tempDir,
       ),
     ).toBe(path.join(tempDir, 'packages/app/src/foo.ts'));
+    expect(
+      __private__.resolveWithTsconfig(
+        { tsconfig: path.join(tempDir, 'tsconfig-paths-without-base-url.json') },
+        importer,
+        '@config/foo',
+        new Map(),
+        tempDir,
+      ),
+    ).toBe(path.join(tempDir, 'src/foo.ts'));
+    expect(
+      __private__.resolveWithTsconfig(
+        { tsconfig: path.join(tempDir, 'tsconfig-no-paths.json') },
+        importer,
+        'src/foo',
+        new Map(),
+        tempDir,
+      ),
+    ).toBe(path.join(tempDir, 'src/foo.ts'));
+    expect(__private__.resolveWithTsconfig({}, importer, '@app/missing', new Map(), tempDir)).toBeNull();
 
     expect(__private__.resolveImport({}, resolutionCaches, importer, './src/foo', tempDir)).toBe(
       path.join(tempDir, 'src/foo.ts'),
@@ -1015,6 +1034,36 @@ describe('prefer-source-imports private helpers', () => {
 
     vi.spyOn(fs, 'existsSync').mockReturnValue(false);
     expect(__private__.resolveWithTsconfig({}, importer, '@app/foo', new Map(), validDir)).toBeNull();
+  });
+
+  it('supports case-insensitive TypeScript resolution caches and relative base URLs', () => {
+    const tempDir = makeTempDir();
+    const importer = path.join(tempDir, 'consumer.ts');
+    const tsconfigPath = path.join(tempDir, 'tsconfig.json');
+
+    writeFiles(tempDir, {
+      'src/foo.ts': 'export const Foo = 1;',
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: { baseUrl: '.', paths: { '@app/*': ['src/*'] } },
+      }),
+    });
+
+    __private__.setTypeScriptModuleLoaderForTests(
+      () =>
+        ({
+          ...typescript,
+          sys: { ...typescript.sys, useCaseSensitiveFileNames: false },
+          parseJsonConfigFileContent: (...args: Parameters<typeof typescript.parseJsonConfigFileContent>) => {
+            const parsedConfig = typescript.parseJsonConfigFileContent(...args);
+
+            return { ...parsedConfig, options: { ...parsedConfig.options, baseUrl: '.' } };
+          },
+        }) as any,
+    );
+
+    expect(
+      __private__.resolveWithTsconfig({ tsconfig: tsconfigPath }, importer, '@app/foo', new Map(), tempDir),
+    ).toBeNull();
   });
 
   it('covers alias-preservation branches and cached barrel analysis', () => {


### PR DESCRIPTION
## Summary

Improves `prefer-source-imports` performance in large TypeScript projects without changing diagnostics or autofix behavior.

- Share nearest-tsconfig lookup, parsed tsconfig data, and TypeScript module-resolution caches across ESLint's per-file rule instances.
- Share parsed barrel analyses across rule instances.
- Skip TypeScript resolution for imports that are neither a configured `paths` alias nor a real `baseUrl` module.
- Skip resolution entirely for default-only and namespace-only imports, which are outside this rule's named-import scope.

## Root cause

ESLint creates a rule instance per file. The rule's caches were created inside each instance, repeatedly rediscovering and parsing the same tsconfig files and resolving external packages that the rule ultimately ignores.

## Validation

- `npm test` — 91 tests passed
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Real-world performance harness with the linked local plugin checkout:
  - Cal.com: 1,209 files, 46 unchanged reports, 10.7s enabled / 3.9s rule overhead in the final one-run measurement
  - shadcn/ui: 164 files, 58 unchanged reports, 3.1s enabled

