### PR TITLE
feat: rewrite direct default barrel imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ This rule is useful when:
 Current scope:
 
 - the rule focuses on named imports
-- default imports from a barrel are not rewritten
+- default imports are rewritten when the barrel directly re-exports its default export
 - namespace imports are not the target of this rule
 
 #### Safe autofix behavior

--- a/src/rules/prefer-source-imports.ts
+++ b/src/rules/prefer-source-imports.ts
@@ -50,6 +50,7 @@ import {
   MessageIds,
   NamedImportSpecifier,
   Options,
+  SupportedImportSpecifier,
 } from './prefer-source-imports/types';
 
 function isNamedImportSpecifier(specifier: TSESTree.ImportClause): specifier is NamedImportSpecifier {
@@ -58,6 +59,10 @@ function isNamedImportSpecifier(specifier: TSESTree.ImportClause): specifier is 
     specifier.imported.type === AST_NODE_TYPES.Identifier &&
     specifier.local.type === AST_NODE_TYPES.Identifier
   );
+}
+
+function isSupportedImportSpecifier(specifier: TSESTree.ImportClause): specifier is SupportedImportSpecifier {
+  return specifier.type === AST_NODE_TYPES.ImportDefaultSpecifier || isNamedImportSpecifier(specifier);
 }
 
 function shouldReportMissingTypeScript(_filename: string, options: Options[0] | undefined): boolean {
@@ -140,9 +145,9 @@ const preferSourceImports: TSESLint.RuleModule<MessageIds, Options> = {
           return;
         }
 
-        const namedSpecifiers = node.specifiers.filter(isNamedImportSpecifier);
+        const supportedSpecifiers = node.specifiers.filter(isSupportedImportSpecifier);
 
-        if (namedSpecifiers.length === 0) {
+        if (supportedSpecifiers.length === 0) {
           return;
         }
 
@@ -168,9 +173,12 @@ const preferSourceImports: TSESLint.RuleModule<MessageIds, Options> = {
 
         const matchedSpecifiers: Array<MatchedSpecifier> = [];
 
-        namedSpecifiers.forEach(specifier => {
-          const specifierIsTypeOnly = isTypeOnlyImport(node, specifier);
-          const reExportKey = getReExportKey(specifier.imported.name, specifierIsTypeOnly);
+        supportedSpecifiers.forEach(specifier => {
+          const specifierIsTypeOnly =
+            specifier.type === AST_NODE_TYPES.ImportSpecifier ? isTypeOnlyImport(node, specifier) : false;
+          const importedName =
+            specifier.type === AST_NODE_TYPES.ImportDefaultSpecifier ? 'default' : specifier.imported.name;
+          const reExportKey = getReExportKey(importedName, specifierIsTypeOnly);
           const explicitReExport = barrelAnalysis.explicitReExports.get(reExportKey);
 
           if (explicitReExport) {
@@ -218,7 +226,7 @@ const preferSourceImports: TSESLint.RuleModule<MessageIds, Options> = {
         const canAutoFix =
           matchedSpecifiers.every(({ preferredSourceSpecifier }) => preferredSourceSpecifier !== null) &&
           matchedSpecifiers.length === node.specifiers.length &&
-          node.specifiers.every(specifier => specifier.type === AST_NODE_TYPES.ImportSpecifier);
+          node.specifiers.every(isSupportedImportSpecifier);
         const autofix = canAutoFix ? buildAutofix(sourceCode, node, matchedSpecifiers) : null;
 
         if (autofix) {
@@ -280,6 +288,7 @@ export const __private__ = {
   getTsconfigInfo,
   getTsconfigPath,
   isNamedImportSpecifier,
+  isSupportedImportSpecifier,
   isRelativePath,
   isTypeOnlyImport,
   matchesAliasPattern,

--- a/src/rules/prefer-source-imports/types.ts
+++ b/src/rules/prefer-source-imports/types.ts
@@ -24,9 +24,11 @@ export type NamedImportSpecifier = TSESTree.ImportSpecifier & {
   local: TSESTree.Identifier;
 };
 
+export type SupportedImportSpecifier = NamedImportSpecifier | TSESTree.ImportDefaultSpecifier;
+
 export type MatchedSpecifier = {
   preferredSourceSpecifier: string | null;
-  specifier: NamedImportSpecifier;
+  specifier: SupportedImportSpecifier;
   reExportTarget: ReExportTarget;
 };
 

--- a/src/rules/tests/fixtures/prefer-source-imports/default-barrel.ts
+++ b/src/rules/tests/fixtures/prefer-source-imports/default-barrel.ts
@@ -1,0 +1,1 @@
+export { default } from './default-thing';

--- a/src/rules/tests/prefer-source-imports.test.ts
+++ b/src/rules/tests/prefer-source-imports.test.ts
@@ -16,6 +16,10 @@ ruleTester.run('prefer-source-imports', preferSourceImports, {
       filename: path.join(fixtureDirectory, 'consumer.ts'),
     },
     {
+      code: `import * as Barrel from './barrel';`,
+      filename: path.join(fixtureDirectory, 'consumer.ts'),
+    },
+    {
       code: `import { Missing } from './barrel';`,
       filename: path.join(fixtureDirectory, 'consumer.ts'),
     },
@@ -124,6 +128,12 @@ ruleTester.run('prefer-source-imports', preferSourceImports, {
     },
     {
       code: `import { DefaultThing } from './barrel';`,
+      filename: path.join(fixtureDirectory, 'consumer.ts'),
+      output: `import { default as DefaultThing } from './default-thing';`,
+      errors: [{ messageId: 'preferSourceImports' }],
+    },
+    {
+      code: `import DefaultThing from './default-barrel';`,
       filename: path.join(fixtureDirectory, 'consumer.ts'),
       output: `import { default as DefaultThing } from './default-thing';`,
       errors: [{ messageId: 'preferSourceImports' }],


### PR DESCRIPTION
Adds safe autofix support for default imports when a barrel directly re-exports its default export. Namespace imports and mixed declarations remain unchanged.\n\nValidation: npm run test:coverage, npm run typecheck, npm run lint, npm run build.