### PR TITLE
feat: ignore intentional barrel imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,9 +182,20 @@ Controls how the replacement import path is generated.
 Skips imports whose source specifier matches one of the supplied glob patterns. Use this for intentional public barrel APIs while continuing to fix internal barrel imports.
 
 ```js
-{
-  ignore: ['@acme/ui', '@acme/*/public'],
-}
+import noBarrelFiles from 'eslint-plugin-no-barrel-files';
+
+export default [
+  {
+    plugins: {
+      'no-barrel-files': noBarrelFiles,
+    },
+    rules: {
+      'no-barrel-files/prefer-source-imports': ['error', {
+        ignore: ['@acme/ui', '@acme/*/public'],
+      }],
+    },
+  },
+];
 ```
 
 ### `tsconfig`

--- a/README.md
+++ b/README.md
@@ -177,6 +177,16 @@ Controls how the replacement import path is generated.
 - `"auto"`
   Preserves aliases for alias-based imports when the reverse alias mapping is unique; otherwise falls back to a relative path.
 
+### `ignore`
+
+Skips imports whose source specifier matches one of the supplied glob patterns. Use this for intentional public barrel APIs while continuing to fix internal barrel imports.
+
+```js
+{
+  ignore: ['@acme/ui', '@acme/*/public'],
+}
+```
+
 ### `tsconfig`
 
 Controls tsconfig-based path resolution.

--- a/src/rules/prefer-source-imports.ts
+++ b/src/rules/prefer-source-imports.ts
@@ -1,4 +1,5 @@
 import { AST_NODE_TYPES, TSESLint, TSESTree } from '@typescript-eslint/utils';
+import { minimatch } from 'minimatch';
 import {
   createAnalysisCaches,
   collectAllExportedBindings,
@@ -90,6 +91,10 @@ const preferSourceImports: TSESLint.RuleModule<MessageIds, Options> = {
             type: 'string',
             enum: ['auto', 'preserve-alias', 'relative'],
           },
+          ignore: {
+            type: 'array',
+            items: { type: 'string' },
+          },
           tsconfig: {
             anyOf: [{ type: 'boolean' }, { type: 'string' }],
           },
@@ -142,6 +147,10 @@ const preferSourceImports: TSESLint.RuleModule<MessageIds, Options> = {
         }
 
         if (!node.source.value || typeof node.source.value !== 'string' || node.specifiers.length === 0) {
+          return;
+        }
+
+        if (options?.ignore?.some(pattern => minimatch(node.source.value, pattern))) {
           return;
         }
 

--- a/src/rules/prefer-source-imports/types.ts
+++ b/src/rules/prefer-source-imports/types.ts
@@ -6,6 +6,7 @@ export type MessageIds = 'missingTypeScript' | 'preferSourceImport' | 'preferSou
 export type Options = [
   {
     fixStyle?: 'auto' | 'preserve-alias' | 'relative';
+    ignore?: string[];
     paths?: Record<string, string | string[]>;
     tsconfig?: boolean | string;
   }?,

--- a/src/rules/tests/prefer-source-imports.test.ts
+++ b/src/rules/tests/prefer-source-imports.test.ts
@@ -43,6 +43,11 @@ ruleTester.run('prefer-source-imports', preferSourceImports, {
       code: `import { LocalNamespace } from './local-barrel-namespace';`,
       filename: path.join(fixtureDirectory, 'consumer.ts'),
     },
+    {
+      code: `import { Foo } from '@app/barrel';`,
+      filename: path.join(fixtureDirectory, 'consumer.ts'),
+      options: [{ ignore: ['@app/*'] }],
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Adds an ignore glob option to prefer-source-imports for intentional public barrel APIs. Matching imports are skipped before resolution and barrel analysis.\n\nValidation: npm run test:coverage, npm run typecheck, npm run lint, npm run build.